### PR TITLE
Brute-force

### DIFF
--- a/kafka/client_test.go
+++ b/kafka/client_test.go
@@ -92,18 +92,6 @@ func TestClient_getConsumerOffsets(t *testing.T) {
 		CoordinatorPort: leader.Port(),
 	})
 
-	leader.Returns(&sarama.DescribeGroupsResponse{
-		Groups: []*sarama.GroupDescription{{
-			Err:     sarama.ErrNoError,
-			GroupId: "test",
-			Members: map[string]*sarama.GroupMemberDescription{
-				"test": {
-					MemberAssignment: []byte{0, 0, 0, 0, 0, 1, 0, 0x04, 't', 'e', 's', 't', 0, 0, 0, 0x01, 0, 0, 0, 0, 0, 0, 0, 0x01, 0},
-				},
-			},
-		}},
-	})
-
 	offset := new(sarama.OffsetFetchResponse)
 	offset.AddBlock("test", 0, &sarama.OffsetFetchResponseBlock{
 		Err:    sarama.ErrNoError,


### PR DESCRIPTION
If the group is being consumed or not, we should get  the offsets this
way. This stops lag not being reported when a consumer disconnects