### PR TITLE
fix copy/paste logging bug when logging partition error

### DIFF
--- a/kafka/monitor.go
+++ b/kafka/monitor.go
@@ -244,7 +244,7 @@ func (m *Monitor) getBrokerMetadata() {
 		partitionCount := len(topic.Partitions)
 		for _, partition := range topic.Partitions {
 			if partition.Err != sarama.ErrNoError {
-				m.log.Error(fmt.Sprintf("monitor: cannot get topic partition metadata %s %d: %v", topic.Name, partition.ID, topic.Err.Error()))
+				m.log.Error(fmt.Sprintf("monitor: cannot get topic partition metadata %s %d: %v", topic.Name, partition.ID, partition.Err.Error()))
 				continue
 			}
 


### PR DESCRIPTION
I was wondering about this line in our logs:

```
... lvl=eror msg="monitor: cannot get topic partition metadata topic 7: kafka server: Not an error, why are you printing me?"
```

and found this bug.